### PR TITLE
uri encode file name

### DIFF
--- a/src/sync/gitlab.js
+++ b/src/sync/gitlab.js
@@ -12,7 +12,7 @@ class gitlab {
   async get(){
     try {
       const response = await axios.get(
-        `${this.config.api_url}/api/v4/projects/${this.config.id_project}/repository/files/${this.config.name_file}/raw?ref=${this.config.ref}&private_token=${this.config.token}`
+        `${this.config.api_url}/api/v4/projects/${this.config.id_project}/repository/files/${encodeURIComponent(this.config.name_file)}/raw?ref=${this.config.ref}&private_token=${this.config.token}`
       );
       return response.data;
     }catch (e) {


### PR DESCRIPTION
Dear Fabio,

if the json file is not in the root of the gitlab project but in a subfolder, the slash has to be encoded in the config. Could you please consider merging that after reviewing? Thanks for providing this plugin!

Best regards
Paul